### PR TITLE
Fixups for 0.17+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .ipynb_checkpoints
-.venv
+.venv3
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ sudo add-apt-repository ppa:bitcoin/bitcoin && sudo apt-get update
 
 Create and activate your virtual environment (not strictly required):
 ```
-$ python3 -m venv .venv3 && virtualenv .venv3/bin/activate
+$ python3 -m venv .venv3 && source .venv3/bin/activate
 ```
 
 Install dependencies:

--- a/test_framework/util.py
+++ b/test_framework/util.py
@@ -289,6 +289,7 @@ def initialize_datadir(dirname, n):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w', encoding='utf8') as f:
         f.write("regtest=1\n")
+        f.write("[regtest]\n")
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")


### PR DESCRIPTION
I was unable to activate the virtual environment using the commands in the README. Ive changed to 

`source .venv3/bin/activate`

which now works (macOS)